### PR TITLE
Properly sort bins and items

### DIFF
--- a/src/3D/Packer.js
+++ b/src/3D/Packer.js
@@ -128,11 +128,11 @@ export default class Packer {
 
   pack() {
     this.bins.sort((a, b) => {
-      return a.getVolume() > b.getVolume();
+      return b.getVolume() - a.getVolume();
     });
 
     this.items.sort((a, b) => {
-      return a.getVolume() > b.getVolume();
+      return b.getVolume() - a.getVolume();
     });
 
     while (this.items.length > 0) {


### PR DESCRIPTION
This is just assuming (haven't read the paper) the algorithm should place bigger volumes first. By reading the code, it seems that was the original intention. [Array.prototype.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) expects the comparator function to return a negative number if the first element should be placed before the second one; and positive otherwise, while 0 would mean to keep both items in the same order they're encountered. For example
```
[1,2,3,4].sort((a,b) => b>a) //-> [1, 2, 3, 4]
[1,2,3,4].sort((a,b) => a>b) //->  [1, 2, 3, 4]
[1,2,3,4].sort((a,b) => b-a) //-> [4, 3, 2, 1]
```
The last one seems to be the desired behaviour.