### PR TITLE
Add "best fit" rotation order logic

### DIFF
--- a/src/3D/Bin.js
+++ b/src/3D/Bin.js
@@ -53,13 +53,79 @@ export default class Bin {
     return ! maxWeight || item.getWeight() + this.getPackedWeight() <= maxWeight;
   }
 
-  putItem(item, p) {
-    let box = this;
-    let fit = false;
+  /**
+   * Calculate a score for a given item and rotation type.
+   *
+   * Scores are higher for rotations that closest match item dimensions to Bin dimensions.
+   * For example, rotating the item so the longest side is aligned with the longest Bin side.
+   *
+   * Example (Bin is 11 x 8.5 x 5.5, Item is 8.1 x 5.2 x 5.2):
+   *  Rotation 0:
+   *    8.1 / 11  = 0.736
+   *    5.2 / 8.5 = 0.612
+   *    5.2 / 5.5 = 0.945
+   *    -----------------
+   *    0.736 ** 2 + 0.612 ** 2 + 0.945 ** 2 = 1.809
+   *
+   *  Rotation 1:
+   *    8.1 / 8.5 = 0.953
+   *    5.2 / 11 = 0.473
+   *    5.2 / 5.5 = 0.945
+   *    -----------------
+   *    0.953 ** 2 + 0.473 ** 2 + 0.945 ** 2 = 2.025
+   *
+   * @param {Item} item
+   * @param {int} rotationType
+   * @return {float} score
+   */
+  scoreRotation(item, rotationType) {
+    item.rotationType = rotationType;
+    let d = item.getDimension();
 
+    // If the item doesn't fit in the Bin
+    if ( this.getWidth() < d[0] || this.getHeight() < d[1] || this.getDepth() < d[2] ) {
+        return 0;
+    }
+
+    // Square the results to increase the impact of high values (e.g. > 0.8)
+    const widthScore = Math.pow( d[0] / this.getWidth(), 2 );
+    const heightScore = Math.pow( d[1] / this.getHeight(), 2 );
+    const depthScore = Math.pow( d[2] / this.getDepth(), 2 );
+
+    return widthScore + heightScore + depthScore;
+  }
+
+  /**
+   * Calculate the best rotation order for a given Item based on scoreRotation().
+   *
+   * @param {Item} item
+   * @return {Array} Rotation types sorted by their score, DESC
+   */
+  getBestRotationOrder(item) {
+    const rotationScores = {};
+
+    // Score all rotation types
+	for (let i=0; i<item.allowedRotation.length; i++) {
+		rotationScores[i] = this.scoreRotation( item, item.allowedRotation[i] );
+    }
+
+    // Sort the rotation types (index of scores object) DESC
+    // and ensure Int values (Object.keys returns strings)
+    const sortedRotations = Object.keys( rotationScores ).sort( ( a, b ) => {
+      return rotationScores[b] - rotationScores[a];
+    } ).map( Number );
+
+    return sortedRotations;
+  }
+
+  putItem(item, p) {
+    const box = this;
+    let fit = false;
+    const rotations = this.getBestRotationOrder( item );
     item.position = p;
-    for (let i=0; i<item.allowedRotation.length; i++) {
-      item.rotationType = item.allowedRotation[i];
+
+    for ( let i = 0; i < rotations.length; i++ ) {
+      item.rotationType = rotations[i];
       let d = item.getDimension();
 
       if (box.getWidth() < p[0] + d[0] || box.getHeight() < p[1] + d[1] || box.getDepth() < p[2] + d[2]) {

--- a/test/3DTest.js
+++ b/test/3DTest.js
@@ -121,7 +121,22 @@ const testDatas = [
       return packer.bins[0].items.length === 2
         && packer.unfitItems.length === 1;
     }
-  }
+  },
+  {
+    name: 'First item fits without rotation but needs to be rotated to fit all items.',
+    bins: [
+      new Bin('USPS Medium Flat Rate Box (Top Loading)', 11, 8.5, 5.5, 1500),
+    ],
+    items: [
+      new Item('Item 1', 8.1, 5.2, 5.2, 20),
+      new Item('Item 2', 8.1, 5.2, 5.2, 20),
+    ],
+    expectation: function (packer) {
+
+      return packer.bins[0].items.length === 2
+        && packer.unfitItems.length === 0;
+    }
+  },
 ];
 
 describe('bp3d.js', function() {


### PR DESCRIPTION
Problem
Two (2) items of dimensions 8.1 x 5.2 x 5.2 should fit in a box with inner dimensions of 11 x 8.5 x 5.5.

Cause
For the first item to be packed in a bin, the packing algorithm takes the first rotation that fits the item. In this particular case, the first rotation allows for the first item to fit the bin, but not the second item.

Solution

The documentation of the proposed heuristic explains it a bit better:
```
/**
   * Calculate a score for a given item and rotation type.
   *
   * Scores are higher for rotations that closest match item dimensions to Bin dimensions.
   * For example, rotating the item so the longest side is aligned with the longest Bin side.
   *
   * Example (Bin is 11 x 8.5 x 5.5, Item is 8.1 x 5.2 x 5.2):
   *  Rotation 0:
   *    8.1 / 11  = 0.736
   *    5.2 / 8.5 = 0.612
   *    5.2 / 5.5 = 0.945
   *    -----------------
   *    0.736 ** 2 + 0.612 ** 2 + 0.945 ** 2 = 1.809
   *
   *  Rotation 1:
   *    8.1 / 8.5 = 0.953
   *    5.2 / 11 = 0.473
   *    5.2 / 5.5 = 0.945
   *    -----------------
   *    0.953 ** 2 + 0.473 ** 2 + 0.945 ** 2 = 2.025
```
Testing Performed
A new test case was added to confirm that the reported bug was solved.